### PR TITLE
Remove broken link on "Importance of Reflection"

### DIFF
--- a/prep-curriculum/core-reflection.md
+++ b/prep-curriculum/core-reflection.md
@@ -60,7 +60,6 @@ Electronic discussions (e.g., chat, e-mail, online forum)
 
 ### Resources
 - [Harvard Business School - Learning By Thinking: How Reflection Improves Performance](https://hbswk.hbs.edu/item/learning-by-thinking-how-reflection-improves-performance)
-- [The Importance of Reflection](https://www.trainingzone.co.uk/develop/talent/the-importance-of-reflection)
 - [Reflection. How do we do it](https://www.cetl.hku.hk/workshop160405/)
 
 


### PR DESCRIPTION
The second learning link, "Importance of Reflection" appears to no longer exist on the host site. I searched their site for alternatives, but I can't find one that seems like it fits with the curriculum section.

This commit removes the broken link, in lieu of replacing it.