### PR TITLE
remove broken link for AFB in accessibility

### DIFF
--- a/prep-curriculum/tech-web-accessibility.md
+++ b/prep-curriculum/tech-web-accessibility.md
@@ -32,4 +32,3 @@ To learn a bit about accessibility before we get started, please take a few mome
 - [W3C Web Accessibility Initiative](https://www.w3.org/WAI/intro/accessibility.php)
 - [Accessible technology at the UW](http://www.washington.edu/accessibility/web/)
 - [Introduction to Web Accessibility](https://developers.googleblog.com/2013/09/make-your-website-more-accessible-to.html) (Google)
-- [Designing an accessible website](http://www.afb.org/info/programs-and-services/technology-evaluation/creating-accessible-websites/123) (AFB)


### PR DESCRIPTION
American Foundation for Blind guide on designing accessible websites no longer exists.